### PR TITLE
MIG: migrar reporte a BS4

### DIFF
--- a/l10n_cl_hr/views/report_payslip.xml
+++ b/l10n_cl_hr/views/report_payslip.xml
@@ -1,386 +1,476 @@
 <?xml version="1.0" encoding="utf-8"?>
-	<odoo>
-	<data>
+<odoo>
 	<template id="hr_payroll.report_payslip">
-	<t t-call="web.html_container">
-        <t t-foreach="docs" t-as="o">
-					<t t-call="web.external_layout">
-            <div class="page">
-                <h3 align="center"><span t-raw="o.name"/></h3>
-                <table class="table-condensed " width="100%" style="margin-top:30px; border-top: 3px solid black;">
-                  <thead>
-                     <tr>
-                        <th colspan="2" width="67%"><strong>Razón Social</strong></th>
-                        <th colspan="2" width="33%" style="text-align:right"><strong>RUT Empresa</strong></th>
-                     </tr>
-                  </thead>
-                  <tbody>
-                      <tr>
-                          <th colspan="2" width="67%"><span t-field="res_company.name"/></th>
-                          <t t-if="res_company.vat">
-                            <th colspan="2" width="33%" style="text-align:right"><span  t-raw="res_company.vat.replace('CL', ' ')"/></th>
-                          </t>
-                          <t t-if="not res_company.vat">
-                            <th colspan="2" width="33%" style="text-align:right">55.555.555-5</th>
-                          </t>
-                      </tr>
-                  </tbody>
-                </table>
+		<t t-call="web.html_container">
+			<t t-foreach="docs" t-as="o">
+				<t t-call="web.external_layout">
+					<div class="page small">
+						<h5 align="center">
+							<span t-raw="o.name" />
+						</h5>
+						<table class="table table-sm"
+							style="border-top: 3px solid black; margin-bottom: 0px;">
+							<thead>
+								<tr>
+									<th colspan="2" width="67%">
+										<strong>Razón Social</strong>
+									</th>
+									<th colspan="2" width="33%" style="text-align:right">
+										<strong>RUT Empresa</strong>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<th colspan="2" width="67%">
+										<span t-field="res_company.name" />
+									</th>
+									<t t-if="res_company.vat">
+										<th colspan="2" width="33%" style="text-align:right">
+											<span t-raw="res_company.vat.replace('CL', ' ')" />
+										</th>
+									</t>
+									<t t-if="not res_company.vat">
+										<th colspan="2" width="33%" style="text-align:right">55.555.555-5</th>
+									</t>
+								</tr>
+							</tbody>
+						</table>
+						<table class="table table-sm"
+							style="border-top: 1px solid black; margin-bottom: 0px;"
+							name="datos_trabajador">
+							<thead>
+								<tr>
+									<th colspan="3" width="31%">
+										<strong>Nombre Trabajador</strong>
+									</th>
+									<th colspan="3" width="36%">
+										<strong>Fecha Ingreso</strong>
+									</th>
+									<th colspan="3" width="33%" style="text-align:right">
+										<strong>RUT Trabajador</strong>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<th colspan="3" width="31%">
+										<span t-field="o.employee_id.name" />
+									</th>
+									<th colspan="3" width="36%">
+										<span t-field="o.contract_id.date_start" />
+									</th>
+									<th colspan="3" width="33%" style="text-align:right">
+										<span t-field="o.employee_id.identification_id" />
+									</th>
+								</tr>
+							</tbody>
+						</table>
+						<table class="table table-sm"
+							style="border-top: 1px solid black; margin-bottom: 0px;"
+							name="datos_org">
+							<thead>
+								<tr>
+									<th colspan="4" width="31%">
+										<strong>Departamento</strong>
+									</th>
+									<th colspan="4" width="22%">
+										<strong>Cargo</strong>
+									</th>
+									<th colspan="4" width="22%">
+										<strong>Tipo Contrato</strong>
+									</th>
+									<th colspan="4" width="25%" style="text-align:right">
+										<strong>Centro Costo</strong>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<th colspan="4" width="31%">
+										<span t-field="o.contract_id.department_id" />
+									</th>
+									<th colspan="4" width="22%">
+										<t t-if="not o.contract_id.job_id">
+											<span>--</span>
+										</t>
+										<t t-if="o.contract_id.job_id">
+											<span t-field="o.contract_id.job_id" />
+										</t>
+									</th>
+									<th colspan="4" width="22%" style="text-align:left">
+										<span t-field="o.contract_id.type_id" />
+									</th>
+									<th colspan="4" width="25%" style="text-align:right">
+										<t t-if="not o.contract_id.analytic_account_id">
+											<span>0001</span>
+										</t>
+										<t t-if="o.contract_id.analytic_account_id">
+											<span t-field="o.contract_id.analytic_account_id.code" />
+										</t>
+									</th>
+								</tr>
+							</tbody>
+						</table>
+						<table class="table table-sm"
+							style="border-top: 1px solid black; margin-bottom: 0px;"
+							name="prevision">
+							<thead>
+								<tr>
+									<th colspan="5" width="17%">
+										<strong>Nombre AFP</strong>
+									</th>
+									<th colspan="5" width="14%">
+										<strong>Tasa AFP</strong>
+									</th>
+									<th colspan="5" width="22%">
+										<strong>Nombre ISAPRE</strong>
+									</th>
+									<th colspan="5" width="18%">
+										<strong>FUN ISAPRE</strong>
+									</th>
+									<th colspan="5" width="14%" style="text-align:left">
+										<strong>Cotiz. UF</strong>
+									</th>
+									<th colspan="5" width="15%" style="text-align:right">
+										<strong>Cotiz. CLP</strong>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<th colspan="5" width="17%">
+										<span t-field="o.contract_id.afp_id" />
+									</th>
+									<th colspan="5" width="14%">
+										<t t-if="('MODELO' == o.contract_id.afp_id.name)">
+											<span t-raw="o.indicadores_id.tasa_afp_modelo" />
+										</t>
+										<t t-if="('CUPRUM' == o.contract_id.afp_id.name)">
+											<span t-raw="o.indicadores_id.tasa_afp_cuprum" />
+										</t>
+										<t t-if="('HABITAT' == o.contract_id.afp_id.name)">
+											<span t-raw="o.indicadores_id.tasa_afp_habitat" />
+										</t>
+										<t t-if="('PLANVITAL' == o.contract_id.afp_id.name)">
+											<span t-raw="o.indicadores_id.tasa_afp_planvital" />
+										</t>
+										<t t-if="('PROVIDA' == o.contract_id.afp_id.name)">
+											<span t-raw="o.indicadores_id.tasa_afp_provida" />
+										</t>
+										<t t-if="('CAPITAL' == o.contract_id.afp_id.name)">
+											<span t-raw="o.indicadores_id.tasa_afp_capital" />
+										</t>
+										%
+									</th>
+									<th colspan="5" width="22%">
+										<span t-field="o.contract_id.isapre_id" />
+									</th>
+									<th colspan="5" width="18%">
+										<span t-field="o.contract_id.isapre_fun" />
+									</th>
+									<th colspan="5" width="14%" style="text-align:left">
+										<span t-field="o.contract_id.isapre_cotizacion_uf" />
+										UF
+									</th>
+									<th colspan="5" width="15%" style="text-align:right">
+										<t t-if="('FONASA' == o.contract_id.isapre_id.name)">
+											<t
+												t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+												t-as="p">
+												<t t-if="('SALUD' == p.code)">
+													<span t-field="p.amount"
+														t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}' />
+												</t>
+											</t>
+										</t>
+										<t t-if="('FONASA' != o.contract_id.isapre_id.name)">
+											<span
+												t-esc="o.indicadores_id.uf*o.contract_id.isapre_cotizacion_uf"
+												t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}' />
+										</t>
+									</th>
+								</tr>
+							</tbody>
+						</table>
+						<table class="table table-sm"
+							style="border-top: 1px solid black; margin-bottom: 0px;"
+							name="jornada">
+							<thead>
+								<tr>
+									<th colspan="6" width="17%">
+										<strong>DIAS</strong>
+									</th>
+									<th colspan="6" width="14%">
+										<strong>H.EXTRA</strong>
+									</th>
+									<th colspan="6" width="22%">
+										<strong>DESCUENTOS</strong>
+									</th>
+									<th colspan="6" width="18%">
+										<strong>CARGAS</strong>
+									</th>
+									<th colspan="6" width="14%" style="text-align:left">
+										<strong>Imponible</strong>
+									</th>
+									<th colspan="6" width="15%" style="text-align:right">
+										<strong>Tributable</strong>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<th colspan="6" width="17%">
+										<t t-set="f" t-value="0" />
+										<t t-foreach="o.worked_days_line_ids" t-as="p">
+											<t t-if="('WORK100' == p.code)">
+												<t t-set="f" t-value="f+p.number_of_days" />
+											</t>
+										</t>
+										<span>
+											<t t-esc="str(int(f))" />
+										</span>
+									</th>
+									<th colspan="6" width="14%">
+										<t t-foreach="o.input_line_ids" t-as="p">
+											<t t-if="(p.code in ['HEX50', 'HEX100'])">
+												<span t-raw="p.amount" />
+											</t>
+										</t>
+									</th>
+									<th colspan="6" width="22%">
+										<t t-foreach="o.input_line_ids" t-as="p">
+											<t t-if="('HEXDE' == p.code)">
+												<span t-raw="p.amount" />
+											</t>
+										</t>
+									</th>
+									<th colspan="6" width="18%">
+										<span t-field="o.contract_id.carga_familiar" />
+										/
+										<span t-field="o.contract_id.carga_familiar_maternal" />
+										/
+										<span t-field="o.contract_id.carga_familiar_invalida" />
+									</th>
+									<th colspan="6" width="14%" style="text-align:left">
+										<t
+											t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+											t-as="p">
+											<t t-if="('TOTIM' == p.code)">
+												<span t-field="p.amount"
+													t-options='{"widget":  "monetary", "display_currency": o.company_id.currency_id}' />
+											</t>
+										</t>
+									</th>
+									<th colspan="6" width="15%" style="text-align:right">
+										<t
+											t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+											t-as="p">
+											<t t-if="'TRIBU' == p.code">
+												<span t-field="p.amount"
+													t-options='{"widget":  "monetary", "display_currency": o.company_id.currency_id}' />
+											</t>
+										</t>
+									</th>
+								</tr>
+							</tbody>
+						</table>
+						<table class="table table-sm"
+							style="border-top: 1px solid black;">
+							<thead>
+								<tr>
+									<th colspan="2">
+										<br />
+									</th>
+								</tr>
+								<tr>
+									<th align="center">
+										<strong>HABERES</strong>
+									</th>
+									<th align="center">
+										<strong>DESCUENTOS</strong>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td style="vertical-align:top;">
+										<table class="table table-sm">
+											<tr
+												t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+												t-as="p">
+												<t
+													t-if=" ('No Imponible' ==p.category_id.name) or ('No Imponible - Otros' ==p.category_id.name) or ('Imponible' ==p.category_id.name) or ('TOTIM' == p.code) or ('TOTNOI' == p.code)">
+													<td>
+														<t t-if="('Subtotal' == p.category_id.name)">
+															<strong t-field="p.name" />
+														</t>
 
-                <table class="table-condensed" width="100%" style="border-top: 1px solid black;" name="datos_trabajador">
-                  <thead>
-                    <tr>
-                        <th colspan="3" width="31%"><strong>Nombre Trabajador</strong></th>
-						<th colspan="3" width="36%"><strong>Fecha Ingreso</strong></th>
-                        <th colspan="3" width="33%" style="text-align:right"><strong>RUT Trabajador</strong></th>                        
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                        <th colspan="3" width="31%"><span t-field="o.employee_id.name"/></th>
-                        <th colspan="3" width="36%"><span t-field="o.contract_id.date_start"/></th>
-                        <th colspan="3" width="33%" style="text-align:right"><span t-field="o.employee_id.identification_id"/></th>
-                    </tr>
-                  </tbody>
-                </table>
+														<t t-if="('Subtotal' != p.category_id.name)">
+															<span t-field="p.name" />
+														</t>
+													</td>
+													<td style="text-align:right">
+														<t t-if="('Subtotal' == p.category_id.name)">
+															<strong t-field="p.total"
+																t-options='{"widget":  "monetary", "display_currency": o.company_id.currency_id}' />
+														</t>
+														<t t-if="('Subtotal' != p.category_id.name)">
+															<span t-field="p.total"
+																t-options='{"widget":  "monetary", "display_currency": o.company_id.currency_id}' />
+														</t>
+													</td>
+												</t>
+											</tr>
+										</table>
+									</td>
+									<td style="vertical-align:top;">
+										<table class="table table-sm">
+											<tr
+												t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+												t-as="p">
+												<t
+													t-if="('Prevision' ==p.category_id.name) or ('Salud' ==p.category_id.name) or ('Descuentos' ==p.category_id.name) or ('Otros Descuentos' ==p.category_id.name) or ('TOD' == p.code) or ('TODELE' == p.code)">
+													<td>
+														<t t-if="('Subtotal' == p.category_id.name)">
+															<strong t-field="p.name" />
+														</t>
+														<t t-if="('Subtotal' != p.category_id.name)">
+															<span t-field="p.name" />
+														</t>
+													</td>
 
-                <table class="table-condensed" width="100%" style="border-top: 1px solid black;" name="datos_org">
-                  <thead>
-                    <tr>
-                        <th colspan="4" width="31%"><strong>Departamento</strong></th>
-                        <th colspan="4" width="22%"><strong>Cargo</strong></th>
-						<th colspan="4" width="22%"><strong>Tipo Contrato</strong></th>
-                        <th colspan="4" width="25%" style="text-align:right"><strong>Centro Costo</strong></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                        <th colspan="4" width="31%"><span t-field="o.contract_id.department_id"/></th>
-                        <th colspan="4" width="22%">
-    						<t t-if="not o.contract_id.job_id">
-     						    <span>--</span>
-							</t>
-    						<t t-if="o.contract_id.job_id">
-     						    <span t-field="o.contract_id.job_id"/>
-							</t>
-						</th>
-						<th colspan="4" width="22%" style="text-align:left"><span t-field="o.contract_id.type_id"/></th>
-						<th colspan="4" width="25%" style="text-align:right">
-                            <t t-if="not o.contract_id.analytic_account_id">
-     						    <span>0001</span>
-							</t>
-    						<t t-if="o.contract_id.analytic_account_id">
-     						    <span t-field="o.contract_id.analytic_account_id.code"/>
-							</t>
-                        </th>
-                    </tr>
-                  </tbody>
-                </table>
-			
-                <table class="table-condensed" width="100%" style="border-top: 1px solid black;" name="prevision">
-                    <thead>
-                      <tr>
-						  <th colspan="5" width="17%"><strong>Nombre AFP</strong></th>
-						  <th colspan="5" width="14%"><strong>Tasa AFP</strong></th>
-                          <th colspan="5" width="22%"><strong>Nombre ISAPRE</strong></th>
-						  <th colspan="5" width="18%"><strong>FUN ISAPRE</strong></th>
-                          <th colspan="5" width="14%" style="text-align:left"><strong>Cotiz. UF</strong></th>
-						  <th colspan="5" width="15%" style="text-align:right"><strong>Cotiz. CLP</strong></th>
-                      </tr>
-                    </thead>	
-                    <tbody>
-                      <tr>
-						  <th colspan="5" width="17%"><span t-field="o.contract_id.afp_id"/></th>
-                          <th colspan="5" width="14%">
-                            <t t-if="('MODELO' == o.contract_id.afp_id.name)">
-                                <span t-raw="o.indicadores_id.tasa_afp_modelo"/>
-                            </t>
-                            <t t-if="('CUPRUM' == o.contract_id.afp_id.name)">
-                                <span t-raw="o.indicadores_id.tasa_afp_cuprum"/>
-                            </t>
-                            <t t-if="('HABITAT' == o.contract_id.afp_id.name)">
-                                <span t-raw="o.indicadores_id.tasa_afp_habitat"/>
-                            </t>
-                            <t t-if="('PLANVITAL' == o.contract_id.afp_id.name)">
-                                <span t-raw="o.indicadores_id.tasa_afp_planvital"/>
-                            </t>
-                            <t t-if="('PROVIDA' == o.contract_id.afp_id.name)">
-                                <span t-raw="o.indicadores_id.tasa_afp_provida"/>
-                            </t>
-                            <t t-if="('CAPITAL' == o.contract_id.afp_id.name)">
-                              <span t-raw="o.indicadores_id.tasa_afp_capital"/>
-                            </t> %
-                          </th>
-                          <th colspan="5" width="22%"><span t-field="o.contract_id.isapre_id"/></th>
-                          <th colspan="5" width="18%"><span t-field="o.contract_id.isapre_fun"/></th>
-  					      <th colspan="5" width="14%" style="text-align:left"><span t-field="o.contract_id.isapre_cotizacion_uf"/> UF</th>
-  					      <th colspan="5" width="15%" style="text-align:right"> 
-                            <t t-if="('FONASA' == o.contract_id.isapre_id.name)">
-                                <t t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-								  <t t-if="('SALUD' == p.code)">
-								    <!--<span t-esc="round(p.amount)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-									<span>CLP <t t-esc="'{0:,.0f}'.format(p.amount)"/></span>
-								  </t>
-								</t>
-                            </t>
-                            <t t-if="('FONASA' != o.contract_id.isapre_id.name)">
-                                <!--<span t-esc="round(o.indicadores_id.uf*o.contract_id.isapre_cotizacion_uf)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-								<span>CLP <t t-esc="'{0:,.0f}'.format(o.indicadores_id.uf*o.contract_id.isapre_cotizacion_uf)"/></span>
-                            </t>
-                          </th>
-                      </tr>
-                  </tbody>
-                </table>
-
-                <table class="table-condensed" width="100%" style="border-top: 1px solid black;" name="jornada">
-                  <thead>
-                    <tr>
-  				        <th colspan="6" width="17%"><strong>DIAS</strong></th>
-						<th colspan="6" width="14%"><strong>H.EXTRA</strong></th>
-						<th colspan="6" width="22%"><strong>DESCUENTOS</strong></th>
-                        <th colspan="6" width="18%"><strong>CARGAS</strong></th>
-                        <th colspan="6" width="14%" style="text-align:left"><strong>Imponible</strong></th>
-						<th colspan="6" width="15%" style="text-align:right"><strong>Tributable</strong></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-  				        <th colspan="6" width="17%">
-                          <t t-set="f" t-value="0"/>
-                          <t t-foreach="o.worked_days_line_ids" t-as="p">
-                            <t t-if="('WORK100' == p.code)">
-                              <t t-set= "f" t-value="f+p.number_of_days"/>
-                            </t>
-                          </t>
-                          <span><t t-esc="str(int(f))"/></span>
-						</th>
-						<th colspan="6" width="14%">
-                          <t t-foreach="o.input_line_ids" t-as="p">
-                            <t t-if="(p.code in ['HEX50', 'HEX100'])">
-                              <span t-raw="p.amount"/>
-                            </t>
-                          </t>
-						</th>
-						<th colspan="6" width="22%">
-                          <t t-foreach="o.input_line_ids" t-as="p">
-                            <t t-if="('HEXDE' == p.code)">
-                              <span t-raw="p.amount"/>
-                            </t>
-                          </t>
-						</th>
-                        <th colspan="6" width="18%">
-                            <span t-field="o.contract_id.carga_familiar"/> / 
-                            <span t-field="o.contract_id.carga_familiar_maternal"/> / 
-                            <span t-field="o.contract_id.carga_familiar_invalida"/>
-						</th>
-                        <th colspan="6" width="14%" style="text-align:left">
-                          <t t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-                            <t t-if="('TOTIM' == p.code)">
-                              <!--CLP <span t-esc="round(p.amount)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-							  <span>CLP <t t-esc="'{0:,.0f}'.format(p.amount)"/></span>
-                            </t>
-                          </t>
-						</th>
-						<th colspan="6" width="15%" style="text-align:right">
-                          <t t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-                            <t t-if="'TRIBU' == p.code">
-                              <!--CLP <span t-esc="round(p.amount)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-							  <span>CLP <t t-esc="'{0:,.0f}'.format(p.amount)"/></span>
-                            </t>
-                          </t>
-						</th>
-                    </tr>
-                  </tbody>
-               </table>
-
-              <!--<table class="table-condensed" width="100%" style="margin-top:20px; border-top: 1px solid black;">
-                  <thead><tr><br></br></tr>				
-                  </thead>
-                  <tbody>     
-				  </tbody>
-			  </table>-->
- 
-			   
-              <table class="table-condensed" width="100%" style="margin-top: 20px; border-top: 1px solid black;">
-                  <thead>
-				     <tr><br></br></tr>
-                     <tr>
-                        <th align="center"><strong>HABERES</strong></th>
-                        <th align="center"><strong>DESCUENTOS</strong></th>
-                     </tr>
-                  </thead>
-                  <tbody>
-                   <tr>
-                       <td style="vertical-align:top;">
-                         <table class="table-condensed" width="100%">
-                           <tr t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-                               <t t-if=" ('No Imponible' ==p.category_id.name) or ('No Imponible - Otros' ==p.category_id.name) or ('Imponible' ==p.category_id.name) or ('TOTIM' == p.code) or ('TOTNOI' == p.code)">
-                                   <td>
-                                     <t t-if=" ('Subtotal' ==p.category_id.name)">
-                                       <strong><span t-field="p.name"/></strong>
-                                     </t>
-
-                                     <t t-if=" ('Subtotal' !=p.category_id.name)">
-                                       <span t-field="p.name"/>
-                                     </t>
-                                   </td>
-                                    <td style="text-align:right">
-                                     <t t-if=" ('Subtotal' ==p.category_id.name)">
-                                       <!--<strong>CLP <span t-esc="round(p.total)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></strong>-->
-									   <strong><span>CLP <t t-esc="'{0:,.0f}'.format(round(p.total))"/></span></strong>
-                                     </t>
-                                     <t t-if=" ('Subtotal' !=p.category_id.name)">
-                                       <!--CLP <span t-esc="round(p.total)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-									   <span>CLP <t t-esc="'{0:,.0f}'.format(round(p.total))"/></span>
-                                     </t>
-                                   </td>
-                               </t>
-                           </tr>
-                         </table>
-                       </td>
-                       <td style="vertical-align:top;">
-                          <table class="table-condensed" width="100%">
-                             <tr t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-                                <t t-if="('Prevision' ==p.category_id.name) or ('Salud' ==p.category_id.name) or ('Descuentos' ==p.category_id.name) or ('Otros Descuentos' ==p.category_id.name) or ('TOD' == p.code) or ('TODELE' == p.code)">
-                                   <td>
-                                       <t t-if=" ('Subtotal' ==p.category_id.name)">
-                                         <strong><span t-field="p.name"/></strong>
-                                       </t>
-
-                                       <t t-if=" ('Subtotal' !=p.category_id.name)">
-                                         <span t-field="p.name"/>
-                                       </t>
-                                    </td>
-
-                                    <td style="text-align:right">
-                                     <t t-if=" ('Subtotal' ==p.category_id.name)">
-                                       <!--<strong>CLP <span t-esc="round(p.total)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></strong>-->
-									   <strong><span>CLP <t t-esc="'{0:,.0f}'.format(p.total)"/></span></strong>
-                                     </t>
-                                     <t t-if=" ('Subtotal' !=p.category_id.name)">
-                                       <!--CLP <span t-esc="round(p.total)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-									   <span>CLP <t t-esc="'{0:,.0f}'.format(p.total)"/></span>
-                                     </t>
-
-                                   </td>
-                                </t>
-                             </tr>
-                          </table>
-                      </td>
-                    </tr>
-                 </tbody>
-              </table>
-
-		  
-              <table class="table-condensed" width="100%" style="margin-top: 50px; border-top: 0px solid white; border-bottom: 0px solid white;">
-                <thead>
-                  <tr>
-                    <td colspan="5" width="25%" style="text-align:left"><h5><strong>TOTAL HABERES</strong></h5></td>
-                    <td colspan="5" width="20%" style="text-align:right">
-					  <t t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-					  <t t-if="('HAB' == p.code)">
-					  <h5>
-					  <!--CLP <span t-esc="round(p.amount)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-					  <strong><span>CLP <t t-esc="'{0:,.0f}'.format(p.amount)"/></span></strong>
-					  </h5>
-					  </t>
-					  </t>
-					</td>
-					<td colspan="5" width="5%" style="text-align:right"> </td>
-					<td colspan="5" width="25%" style="text-align:left"><h5><strong>TOTAL DESCUENTOS</strong></h5></td>
-                    <td colspan="5" width="25%" style="text-align:right">
-					  <t t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-					  <t t-if="('TDE' == p.code)">
-					  <h5>
-					  <!--CLP <span t-esc="round(p.amount)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>-->
-					  <strong><span>CLP <t t-esc="'{0:,.0f}'.format(p.amount)"/></span></strong>
-					  </h5>
-					  </t>
-					  </t>
-					</td>
-                  </tr>
-				</thead>
-			  </table>
-
-              <table class="table-condensed" width="100%" style="margin-top: 50px; border-top: 3px solid white; border-bottom: 0px solid white; background:#efefef;">
-                <thead>
-				  <tr>
-					<td colspan="1" width="50%" style="text-align:left"><strong>Fecha</strong></td>
-                    <td colspan="1" width="50%" style="text-align:right">
-					  <strong><span t-field="o.date_to"/></strong>
-					</td>
-				  </tr>
-                  <tr>
-                    <td colspan="1" width="50%" style="text-align:left"><strong>Alcance Líquido</strong></td>
-                    <td colspan="1" width="50%" style="text-align:right">
-					  <t t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-					    <t t-if="('LIQ' == p.code)"> 
-						  <!--<strong>CLP <span t-esc="round(p.amount)" t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></strong>-->
-						  <strong><span>CLP <t t-esc="'{0:,.0f}'.format(p.amount)"/></span></strong>
-						</t>
-				      </t>
-					</td>
-                  </tr>
-                  <tr>
-                    <td colspan="1" width="50%" style="text-align:left"><strong>Alcance Líquido (en palabras):</strong></td>
-					<td colspan="1" width="50%" style="text-align:right">
-					  <t t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="p">
-					    <t t-if="('LIQ' == p.code) and (p.amount>0)"> 
-						  <span t-esc="o.company_id.currency_id.amount_to_text(p.amount).upper()" />
-						</t>
-				      </t>
-					</td>
-                  </tr>
-				</thead>
-			  </table>
- 
-	  
-			  
-
-              <table class="table-condensed" width="100%" style="margin-top: 30px; margin-bottom: 30px;">
-                <tr>
-                  <td colspan="3">Certifico que recibí de <span t-field="res_company.name"/> a mi entera satisifación el saldo líquido de la presente liquidación, no teniendo cobro alguno que hacer o reclamar por los conceptos correspondientes a ella.<br></br></td>
-                </tr>
-                <tr>
-                  <td><br></br><br></br></td>
-                </tr>
-
-              </table>
-
-              <!--<table class="table-condensed" width="100%" style="margin-top:20px; border-top: 0px solid white;">
-                  <thead>
-				    <tr>
-					  <th>
-					    <span t-field="o.x_studio_nota_interna"/>
-					  </th>
-					</tr>				
-                  </thead>
-                  <tbody>     
-				  </tbody>
-			  </table>-->
-
-			  
-              <table class="table-condensed" width="100%" style="margin-top: 1px; border-bottom:3px 1px solid black;">
-                <tr>
-                  <th colspan="4"><strong>FIRMA DEL EMPLEADOR</strong></th>
-                  <th style="text-align:right"><strong>FIRMA DEL TRABAJADOR</strong></th>
-                </tr>
-                <tr>
-                  <th colspan="4"><span t-field="res_company.name"/></th>
-                  <th style="text-align:right"><span t-field="o.employee_id.name"/></th>
-                </tr>
-
-              </table>
-	          <table class="table-condensed" width="100%" style="margin-top:10px; border-top: 1px solid black;">
-                  <thead><tr><br></br></tr>				
-                  </thead>
-                  <tbody>     
-				  </tbody>
-			  </table>
-            </div>
-		  </t>
-        </t>
-      </t>
-    </template>
-  </data>
+													<td style="text-align:right">
+														<t t-if="('Subtotal' == p.category_id.name)">
+															<strong t-field="p.total"
+																t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}' />
+														</t>
+														<t t-if="('Subtotal' != p.category_id.name)">
+															<span t-field="p.total"
+																t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}' />
+														</t>
+													</td>
+												</t>
+											</tr>
+										</table>
+									</td>
+								</tr>
+								<tr>
+									<td>
+										<h5>
+											<strong>TOTAL HABERES</strong>
+											<t
+												t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+												t-as="p">
+												<t t-if="('HAB' == p.code)">
+													<span class="float-right" t-field="p.amount"
+														t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}' />
+												</t>
+											</t>
+										</h5>
+									</td>
+									<td>
+										<h5>
+											<strong class="ml32">TOTAL DESCUENTOS</strong>
+											<t
+												t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+												t-as="p">
+												<t t-if="('TDE' == p.code)">
+													<span class="float-right" t-field="p.amount"
+														t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}' />
+												</t>
+											</t>
+										</h5>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+						<table class="table table-sm"
+							style="border-top: 3px solid white; border-bottom: 0px solid white; background:#efefef; margin-bottom: 0px;">
+							<thead>
+								<tr>
+									<td colspan="1" width="50%" style="text-align:left">
+										<strong>Fecha</strong>
+									</td>
+									<td colspan="1" width="50%" style="text-align:right">
+										<strong>
+											<span t-field="o.date_to" />
+										</strong>
+									</td>
+								</tr>
+								<tr>
+									<td colspan="1" width="50%" style="text-align:left">
+										<strong>Alcance Líquido</strong>
+									</td>
+									<td colspan="1" width="50%" style="text-align:right">
+										<t
+											t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+											t-as="p">
+											<t t-if="('LIQ' == p.code)">
+												<strong t-field="p.amount"
+													t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}' />
+											</t>
+										</t>
+									</td>
+								</tr>
+								<tr>
+									<td colspan="1" width="50%" style="text-align:left">
+										<strong>Alcance Líquido (en palabras):</strong>
+									</td>
+									<td colspan="1" width="50%" style="text-align:right">
+										<t
+											t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+											t-as="p">
+											<t t-if="('LIQ' == p.code) and (p.amount>0)">
+												<span
+													t-esc="o.company_id.currency_id.amount_to_text(p.amount).upper()" />
+											</t>
+										</t>
+									</td>
+								</tr>
+							</thead>
+						</table>
+						<table class="table table-sm"
+							style="margin-top: 30px; margin-bottom: 30px;">
+							<tr>
+								<td colspan="3">
+									Certifico que recibí de
+									<span t-field="res_company.name" />
+									a mi entera satisifación el saldo líquido de la presente
+									liquidación, no teniendo cobro alguno que hacer o reclamar por
+									los conceptos correspondientes a ella.
+									<br></br>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<br></br>
+									<br></br>
+								</td>
+							</tr>
+						</table>
+						<table class="table table-sm text-center"
+							style="margin-top: 1px; border-bottom:3px 1px solid black;">
+							<tr>
+								<th colspan="4">
+									<strong>FIRMA DEL EMPLEADOR</strong>
+								</th>
+								<th>
+									<strong>FIRMA DEL TRABAJADOR</strong>
+								</th>
+							</tr>
+							<tr>
+								<th colspan="4">
+									<span t-field="res_company.name" />
+								</th>
+								<th>
+									<span t-field="o.employee_id.name" />
+								</th>
+							</tr>
+						</table>
+					</div>
+				</t>
+			</t>
+		</t>
+	</template>
 </odoo>


### PR DESCRIPTION
*cambiar table-condensed por table-sm
*usar widget monetary para tomar la configuracion de la moneda y del idioma(separador de decimales, redondeo y simbolo de moneda), no dejar quemado en codigo dichos datos
*reemplazar t-esc-options por t-options, por ello no funcionaba el widget monetary
*ocupar 1 sola hoja, usar small para que la letra sea un poco mas pequeña y no usar tanto margen entre lineas


**Antes, ocupa 2 hojas**
![image](https://user-images.githubusercontent.com/47437110/57340960-f02c9080-70fd-11e9-9da2-8c659bd11229.png)

**Despues, ocupa 1 hoja**
![image](https://user-images.githubusercontent.com/47437110/57341019-2f5ae180-70fe-11e9-8016-486b88b92869.png)
