### PR TITLE
FIX: crear calendario y dias al mismo tiempo

### DIFF
--- a/l10n_cl_hr/data/resource_calendar_attendance.xml
+++ b/l10n_cl_hr/data/resource_calendar_attendance.xml
@@ -5,49 +5,16 @@
     <!-- Horarios Inputs -->
         <record id="hr_resource_monthly_cl" model="resource.calendar">
             <field name="name">Mensual</field>
-        </record>
-
-    <!-- Horarios Inputs -->
-
-        <record id="hr_resource_calendar_attendance_mon" model="resource.calendar.attendance">
-            <field name="name">Todo el dia</field>
-            <field name="hour_from">8.5</field>
-            <field name="hour_to">18.5</field>
-            <field name="dayofweek">0</field>
-            <field name="day_period">morning</field>
-            <field name="calendar_id"     ref="hr_resource_monthly_cl"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_tue" model="resource.calendar.attendance">
-            <field name="name">Todo el dia</field>
-            <field name="hour_from">8.5</field>
-            <field name="hour_to">18.5</field>
-            <field name="dayofweek">1</field>
-            <field name="calendar_id"     ref="hr_resource_monthly_cl"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_wed" model="resource.calendar.attendance">
-            <field name="name">Todo el dia</field>
-            <field name="hour_from">8.5</field>
-            <field name="hour_to">18.5</field>
-            <field name="dayofweek">2</field>
-            <field name="calendar_id"     ref="hr_resource_monthly_cl"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_thu" model="resource.calendar.attendance">
-            <field name="name">Todo el dia</field>
-            <field name="hour_from">8.5</field>
-            <field name="hour_to">18.5</field>
-            <field name="dayofweek">3</field>
-            <field name="calendar_id"     ref="hr_resource_monthly_cl"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_fri" model="resource.calendar.attendance">
-            <field name="name">Todo el dia</field>
-            <field name="hour_from">8.5</field>
-            <field name="hour_to">18.5</field>
-            <field name="dayofweek">4</field>
-            <field name="calendar_id"     ref="hr_resource_monthly_cl"/>
+	        <field name="hours_per_day">10</field>
+	        <field name="attendance_ids"
+	            eval="[
+	                (0, 0, {'name': 'Todo el dia', 'dayofweek': '0', 'hour_from': 8.5, 'hour_to': 18.5, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Todo el dia', 'dayofweek': '1', 'hour_from': 8.5, 'hour_to': 18.5, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Todo el dia', 'dayofweek': '2', 'hour_from': 8.5, 'hour_to': 18.5, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Todo el dia', 'dayofweek': '3', 'hour_from': 8.5, 'hour_to': 18.5, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Todo el dia', 'dayofweek': '4', 'hour_from': 8.5, 'hour_to': 18.5, 'day_period': 'morning'}),
+	            ]"
+	        />
         </record>
 
         <record id="base.main_company" model="res.company">
@@ -58,71 +25,18 @@
         <record id="hr_resource_helios_prod_3t" model="resource.calendar">
             <field name="name">Prod 3 Turnos</field>
             <field name="tz">America/Santiago</field>
+	        <field name="attendance_ids"
+	            eval="[
+	                (0, 0, {'name': 'Lunes 3T', 'dayofweek': '0', 'hour_from': 7, 'hour_to': 14.49, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Lunes 3T', 'dayofweek': '0', 'hour_from': 14.5, 'hour_to': 23.99, 'day_period': 'afternoon'}),
+	                (0, 0, {'name': 'Martes 3T', 'dayofweek': '1', 'hour_from': 0.0, 'hour_to': 23.99, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Miércoles 3T', 'dayofweek': '2', 'hour_from': 0.0, 'hour_to': 23.99, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Jueves 3T', 'dayofweek': '3', 'hour_from': 0.0, 'hour_to': 23.99, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Viernes 3T', 'dayofweek': '4', 'hour_from': 0.0, 'hour_to': 23.99, 'day_period': 'morning'}),
+	                (0, 0, {'name': 'Sábado 3T', 'dayofweek': '5', 'hour_from': 0.0, 'hour_to': 22.5, 'day_period': 'morning'}),
+	            ]"
+	        />
         </record>
-
-    <!-- Horarios Inputs -->
-
-        <record id="hr_resource_calendar_attendance_mon_3t_am" model="resource.calendar.attendance">
-            <field name="name">Lunes 3T</field>
-            <field name="hour_from">7.0</field>
-            <field name="hour_to">14.49</field>
-            <field name="day_period">morning</field>
-            <field name="dayofweek">0</field>
-            <field name="calendar_id"     ref="hr_resource_helios_prod_3t"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_mon_3t_pm" model="resource.calendar.attendance">
-            <field name="name">Lunes 3T</field>
-            <field name="hour_from">14.5</field>
-            <field name="hour_to">23.99</field>
-            <field name="day_period">afternoon</field>
-            <field name="dayofweek">0</field>
-            <field name="calendar_id"     ref="hr_resource_helios_prod_3t"/>
-        </record>
-
-
-        <record id="hr_resource_calendar_attendance_tue_3t" model="resource.calendar.attendance">
-            <field name="name">Martes 3T</field>
-            <field name="hour_from">0.0</field>
-            <field name="hour_to">23.99</field>
-            <field name="dayofweek">1</field>
-            <field name="calendar_id"     ref="hr_resource_helios_prod_3t"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_wed_3t" model="resource.calendar.attendance">
-            <field name="name">Miércoles 3T</field>
-            <field name="hour_from">0.0</field>
-            <field name="hour_to">23.99</field>
-            <field name="dayofweek">2</field>
-            <field name="calendar_id"     ref="hr_resource_helios_prod_3t"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_thu_3t" model="resource.calendar.attendance">
-            <field name="name">Jueves 3T</field>
-            <field name="hour_from">0.0</field>
-            <field name="hour_to">23.99</field>
-            <field name="dayofweek">3</field>
-            <field name="calendar_id"     ref="hr_resource_helios_prod_3t"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_fri_3t" model="resource.calendar.attendance">
-            <field name="name">Viernes 3T</field>
-            <field name="hour_from">0.0</field>
-            <field name="hour_to">23.99</field>
-            <field name="dayofweek">4</field>
-            <field name="calendar_id"     ref="hr_resource_helios_prod_3t"/>
-        </record>
-
-        <record id="hr_resource_calendar_attendance_sat_3t" model="resource.calendar.attendance">
-            <field name="name">Sábado 3T</field>
-            <field name="hour_from">0.0</field>
-            <field name="hour_to">22.5</field>
-            <field name="dayofweek">5</field>
-            <field name="calendar_id"     ref="hr_resource_helios_prod_3t"/>
-        </record>
-
-
-
  
     </data>
 </odoo>                     

--- a/l10n_cl_hr/data/resource_calendar_attendance.xml
+++ b/l10n_cl_hr/data/resource_calendar_attendance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
+    <data noupdate="1">
 
     <!-- Horarios Inputs -->
         <record id="hr_resource_monthly_cl" model="resource.calendar">

--- a/l10n_cl_hr_employee_shift/models/hr_employee_shift.py
+++ b/l10n_cl_hr_employee_shift/models/hr_employee_shift.py
@@ -35,11 +35,11 @@ class HrEmployeeShift(models.Model):
 
     def _get_default_attendance_ids(self):
         return [
-            (0, 0, {'name': _('Monday Morning'), 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12}),
-            (0, 0, {'name': _('Tuesday Morning'), 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12}),
-            (0, 0, {'name': _('Wednesday Morning'), 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12}),
-            (0, 0, {'name': _('Thursday Morning'), 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12}),
-            (0, 0, {'name': _('Friday Morning'), 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12}),
+            (0, 0, {'name': _('Monday Morning'), 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+            (0, 0, {'name': _('Tuesday Morning'), 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+            (0, 0, {'name': _('Wednesday Morning'), 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+            (0, 0, {'name': _('Thursday Morning'), 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+            (0, 0, {'name': _('Friday Morning'), 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
         ]
 
     color = fields.Integer(string='Color Index')


### PR DESCRIPTION
para evitar que odoo cree las lineas por defecto y se dupliquen

Tomar como ejemplo la manera en que Odoo crea los datos: https://github.com/odoo/odoo/blob/12.0/addons/resource/data/resource_data.xml#L28-L39

**Antes:**

![image](https://user-images.githubusercontent.com/47437110/57350146-7c50af00-7122-11e9-8048-61c250a8b8b2.png)

![image](https://user-images.githubusercontent.com/47437110/57350173-a013f500-7122-11e9-8d12-9abc327d7707.png)


**Despues**

![image](https://user-images.githubusercontent.com/47437110/57350157-8f637f00-7122-11e9-9f20-8e4e087785c5.png)

![image](https://user-images.githubusercontent.com/47437110/57350177-a99d5d00-7122-11e9-98b0-d4760b29849f.png)

